### PR TITLE
Improve metrics tracker aggregation

### DIFF
--- a/sms/metrics_tracker.py
+++ b/sms/metrics_tracker.py
@@ -62,6 +62,19 @@ CONV_CAMPAIGN_FIELD     = os.getenv("CONV_CAMPAIGN_FIELD", "Campaign")  # linked
 DELIVERED_STATES = {"DELIVERED"}          # adjust if you track more granular states
 FAILED_STATES    = {"FAILED", "UNDELIVERED", "UNDELIVERABLE"}
 
+# Keep a reusable list of fields when fetching Conversations to reduce payload size.
+_CONVO_FETCH_FIELDS = sorted({
+    CONV_STATUS_FIELD,
+    CONV_MESSAGE_FIELD,
+    CONV_DIRECTION_FIELD,
+})
+
+# Cache field mappings to avoid repeated Airtable lookups when remapping payload keys.
+_FIELD_MAP_CACHE: dict[tuple[int, Optional[str]], dict[str, str]] = {}
+
+# Expanded opt-out detection to catch more variants beyond "STOP".
+_OPTOUT_RE = re.compile(r"\b(stop|unsubscribe|cancel|quit|end|remove|opt\s*out)\b", re.I)
+
 # ───────────────────────────────────── Airtable factory ──────────────────────────────────────────
 def _make_table(api_key: Optional[str], base_id: Optional[str], table_name: str):
     if not (api_key and base_id):
@@ -97,6 +110,12 @@ def _norm(s: str) -> str:
     return re.sub(r"[^a-z0-9]+", "", s.strip().lower()) if isinstance(s, str) else s
 
 def _auto_field_map(table, sample_record_id: Optional[str] = None) -> dict[str, str]:
+    if not table:
+        return {}
+    key = (id(table), sample_record_id or "__NONE__")
+    cached = _FIELD_MAP_CACHE.get(key)
+    if cached is not None:
+        return cached
     keys: List[str] = []
     try:
         rec = table.get(sample_record_id) if sample_record_id else None
@@ -106,7 +125,9 @@ def _auto_field_map(table, sample_record_id: Optional[str] = None) -> dict[str, 
         keys = list(rec.get("fields", {}).keys())
     except Exception:
         pass
-    return {_norm(k): k for k in keys}
+    amap = {_norm(k): k for k in keys}
+    _FIELD_MAP_CACHE[key] = amap
+    return amap
 
 def _remap_existing_only(table, payload: dict, sample_record_id: Optional[str] = None) -> dict:
     amap = _auto_field_map(table, sample_record_id)
@@ -161,6 +182,45 @@ def _safe_len(x) -> int:
     try: return len(x)
     except Exception: return 0
 
+def _fetch_convos(table, *, formula: str) -> list[dict]:
+    if not table:
+        return []
+    try:
+        if hasattr(table, "iterate"):
+            return list(table.iterate(formula=formula, fields=_CONVO_FETCH_FIELDS))
+    except Exception:
+        traceback.print_exc()
+    try:
+        return table.all(formula=formula, fields=_CONVO_FETCH_FIELDS)
+    except Exception:
+        traceback.print_exc()
+        return []
+
+def _is_optout(message: str | None) -> bool:
+    if not message:
+        return False
+    return bool(_OPTOUT_RE.search(message))
+
+def _compute_convo_metrics(sent: list[dict], inbound: list[dict]) -> dict[str, Any]:
+    total_sent = _safe_len(sent)
+    delivered = sum(1 for r in sent if _status(r) in DELIVERED_STATES)
+    failed = sum(1 for r in sent if _status(r) in FAILED_STATES)
+    responses = _safe_len(inbound)
+    optouts = sum(1 for r in inbound if _is_optout(_body(r)))
+
+    delivery_rate = round((delivered / total_sent * 100), 2) if total_sent else 0.0
+    optout_rate = round((optouts / total_sent * 100), 2) if total_sent else 0.0
+
+    return {
+        "sent": total_sent,
+        "delivered": delivered,
+        "failed": failed,
+        "responses": responses,
+        "optouts": optouts,
+        "delivery_rate": delivery_rate,
+        "optout_rate": optout_rate,
+    }
+
 def _notify(msg: str) -> None:
     print(f"🚨 ALERT: {msg}")
     # SMS alert (best effort)
@@ -189,6 +249,10 @@ def _should_alert(last_alert_at, rate: float, threshold: float) -> bool:
 def _field(name: str) -> str:
     return "{" + name + "}"
 
+def _formula_equals(field: str, value: str) -> str:
+    safe = (value or "").replace("'", r"\'")
+    return f"{_field(field)}='{safe}'"
+
 def _campaign_match_formula(campaign_name: str) -> str:
     """Equality on linked field compares primary values of linked records in Airtable."""
     safe = (campaign_name or "").replace("'", r"\'")
@@ -205,6 +269,55 @@ def _body(rec) -> str:
 def _direction(rec) -> str:
     try: return str(rec["fields"].get(CONV_DIRECTION_FIELD, "")).strip().upper()
     except Exception: return ""
+
+def _kpi_field(table, name: str) -> str:
+    amap = _auto_field_map(table)
+    return amap.get(_norm(name), name)
+
+def _upsert_metric(
+    table,
+    *,
+    campaign: str,
+    metric: str,
+    value: float,
+    day: str,
+    timestamp: str,
+) -> None:
+    if not table:
+        return
+    campaign_field = _kpi_field(table, "Campaign")
+    metric_field = _kpi_field(table, "Metric")
+    date_field = _kpi_field(table, "Date")
+
+    formula = "AND(" + ", ".join(
+        [
+            _formula_equals(campaign_field, campaign),
+            _formula_equals(metric_field, metric),
+            _formula_equals(date_field, day),
+        ]
+    ) + ")"
+
+    existing: list[dict] = []
+    try:
+        existing = table.all(formula=formula, max_records=1)
+    except Exception:
+        traceback.print_exc()
+
+    payload = {
+        campaign_field: campaign,
+        metric_field: metric,
+        _kpi_field(table, "Value"): float(value),
+        date_field: day,
+        _kpi_field(table, "Timestamp"): timestamp,
+    }
+
+    if existing:
+        rec = existing[0]
+        rec_id = rec.get("id")
+        if rec_id:
+            _safe_update(table, rec_id, payload, sample_record_id=rec_id)
+            return
+    _safe_create(table, payload)
 
 # ───────────────────────────────────────── Core ─────────────────────────────────────────────────
 def update_metrics() -> dict:
@@ -223,6 +336,7 @@ def update_metrics() -> dict:
     if not (campaigns and convos):
         return {"ok": False, "error": "Missing Airtable setup (campaigns/conversations tables)"}
 
+    now_ts = _now_iso()
     today = datetime.now(timezone.utc).date().isoformat()
     summary: list[dict] = []
     global_stats = {"sent": 0, "delivered": 0, "failed": 0, "responses": 0, "optouts": 0}
@@ -247,39 +361,29 @@ def update_metrics() -> dict:
             formula_in  = f"AND(LOWER({dir_field})='in',  {fbf_campaign})"
 
             # Outbound
-            try:
-                sent = convos.all(formula=formula_out)
-            except Exception:
-                traceback.print_exc()
-                sent = []
-            total_sent = _safe_len(sent)
-            delivered  = [r for r in sent if _status(r) in DELIVERED_STATES]
-            failed     = [r for r in sent if _status(r) in FAILED_STATES]
+            sent = _fetch_convos(convos, formula=formula_out)
+            inbound = _fetch_convos(convos, formula=formula_in)
 
-            # Inbound (responses)
-            try:
-                inbound = convos.all(formula=formula_in)
-            except Exception:
-                traceback.print_exc()
-                inbound = []
-            responses      = _safe_len(inbound)
-            optouts        = [r for r in inbound if "stop" in _body(r)]  # simple SMS STOP detector
-            total_optouts  = _safe_len(optouts)
-
-            delivery_rate  = round((len(delivered) / total_sent * 100), 2) if total_sent else 0.0
-            optout_rate    = round((total_optouts / total_sent * 100), 2) if total_sent else 0.0
+            metrics = _compute_convo_metrics(sent, inbound)
+            total_sent = metrics["sent"]
+            delivered_count = metrics["delivered"]
+            failed_count = metrics["failed"]
+            responses = metrics["responses"]
+            total_optouts = metrics["optouts"]
+            delivery_rate = metrics["delivery_rate"]
+            optout_rate = metrics["optout_rate"]
 
             # Update Campaigns (strip unknown/computed on the fly)
             # IMPORTANT: Do NOT assume counters are writable; bases often compute them.
             camp_patch = {
                 "total_sent":       total_sent,
-                "total_delivered":  len(delivered),
-                "total_failed":     len(failed),
+                "total_delivered":  delivered_count,
+                "total_failed":     failed_count,
                 "total_replies":    responses,
                 "total_opt_outs":   total_optouts,
                 "delivery_rate":    delivery_rate,
                 "opt_out_rate":     optout_rate,
-                "last_run_at":      _now_iso(),
+                "last_run_at":      now_ts,
             }
             _safe_update(campaigns, camp_id, camp_patch, sample_record_id=camp_id)
 
@@ -296,36 +400,34 @@ def update_metrics() -> dict:
                 _notify(f"⚠️ Low delivery rate for {camp_name}: {delivery_rate}% (sent={total_sent})")
                 alerted = True
             if alerted:
-                _safe_update(campaigns, camp_id, {"last_alert_at": _now_iso()}, sample_record_id=camp_id)
+                _safe_update(campaigns, camp_id, {"last_alert_at": now_ts}, sample_record_id=camp_id)
 
             # KPIs (best effort)
             if kpis:
                 for metric, value in [
                     ("TOTAL_SENT",   total_sent),
-                    ("DELIVERED",    len(delivered)),
-                    ("FAILED",       len(failed)),
+                    ("DELIVERED",    delivered_count),
+                    ("FAILED",       failed_count),
                     ("RESPONSES",    responses),
                     ("OPTOUTS",      total_optouts),
                     ("DELIVERY_RATE",delivery_rate),
                     ("OPTOUT_RATE",  optout_rate),
                 ]:
-                    _safe_create(
+                    _upsert_metric(
                         kpis,
-                        {
-                            "Campaign": camp_name,
-                            "Metric":   metric,
-                            "Value":    float(value),
-                            "Date":     today,
-                            "Timestamp":_now_iso(),
-                        },
+                        campaign=camp_name,
+                        metric=metric,
+                        value=float(value),
+                        day=today,
+                        timestamp=now_ts,
                     )
 
             # Summary row
             summary.append({
                 "campaign":       camp_name,
                 "sent":           total_sent,
-                "delivered":      len(delivered),
-                "failed":         len(failed),
+                "delivered":      delivered_count,
+                "failed":         failed_count,
                 "responses":      responses,
                 "optouts":        total_optouts,
                 "delivery_rate":  delivery_rate,
@@ -334,8 +436,8 @@ def update_metrics() -> dict:
 
             # Global rollup
             global_stats["sent"]       += total_sent
-            global_stats["delivered"]  += len(delivered)
-            global_stats["failed"]     += len(failed)
+            global_stats["delivered"]  += delivered_count
+            global_stats["failed"]     += failed_count
             global_stats["responses"]  += responses
             global_stats["optouts"]    += total_optouts
 
@@ -352,15 +454,13 @@ def update_metrics() -> dict:
             ("RESPONSES",  global_stats["responses"]),
             ("OPTOUTS",    global_stats["optouts"]),
         ]:
-            _safe_create(
+            _upsert_metric(
                 kpis,
-                {
-                    "Campaign": "ALL",
-                    "Metric":   metric,
-                    "Value":    float(value),
-                    "Date":     today,
-                    "Timestamp":_now_iso(),
-                },
+                campaign="ALL",
+                metric=metric,
+                value=float(value),
+                day=today,
+                timestamp=now_ts,
             )
 
     # Runs / Logs
@@ -373,7 +473,7 @@ def update_metrics() -> dict:
                     "Type":      "METRICS_UPDATE",
                     "Processed": float(global_stats["sent"]),
                     "Breakdown": json.dumps(summary, ensure_ascii=False),
-                    "Timestamp": _now_iso(),
+                    "Timestamp": now_ts,
                 },
             )
             run_id = (rec or {}).get("id")

--- a/tests/test_metrics_tracker.py
+++ b/tests/test_metrics_tracker.py
@@ -1,0 +1,143 @@
+from sms import metrics_tracker as mt
+
+
+def test_is_optout_matches_variants():
+    assert mt._is_optout("STOP")
+    assert mt._is_optout("Please unsubscribe me")
+    assert mt._is_optout("I'd like to opt out now")
+    assert not mt._is_optout("Hello there")
+
+
+def _rec(status: str | None = None, message: str | None = None):
+    fields = {}
+    if status is not None:
+        fields[mt.CONV_STATUS_FIELD] = status
+    if message is not None:
+        fields[mt.CONV_MESSAGE_FIELD] = message
+    return {"fields": fields}
+
+
+def test_compute_convo_metrics_counts_correctly():
+    sent = [
+        _rec(status="DELIVERED"),
+        _rec(status="FAILED"),
+    ]
+    inbound = [
+        _rec(message="stop"),
+        _rec(message="Sounds good"),
+    ]
+
+    metrics = mt._compute_convo_metrics(sent, inbound)
+
+    assert metrics == {
+        "sent": 2,
+        "delivered": 1,
+        "failed": 1,
+        "responses": 2,
+        "optouts": 1,
+        "delivery_rate": 50.0,
+        "optout_rate": 50.0,
+    }
+
+
+class DummyTable:
+    def __init__(self, *, match_formula: str | None = None, existing_id: str | None = None):
+        self.match_formula = match_formula
+        self.existing_id = existing_id
+        self.schema = {
+            "Campaign": "",
+            "Metric": "",
+            "Value": 0.0,
+            "Date": "",
+            "Timestamp": "",
+        }
+        self.created = []
+        self.updated = []
+        self.update_calls = []
+
+    def all(self, **kwargs):
+        formula = kwargs.get("formula")
+        if formula:
+            if self.match_formula and formula == self.match_formula and self.existing_id:
+                return [
+                    {
+                        "id": self.existing_id,
+                        "fields": self.schema | {"Campaign": "Camp", "Metric": "TOTAL_SENT", "Date": "2024-01-01"},
+                    }
+                ]
+            return []
+        return [{"fields": self.schema}]
+
+    def get(self, rec_id):
+        if rec_id == self.existing_id:
+            return {"id": rec_id, "fields": self.schema}
+        return None
+
+    def create(self, payload):
+        self.created.append(payload)
+        return {"id": "recNEW", "fields": payload}
+
+    def update(self, rec_id, payload):
+        self.update_calls.append((rec_id, payload))
+        self.updated.append(payload)
+        return {"id": rec_id, "fields": payload}
+
+
+def test_upsert_metric_creates_when_missing():
+    table = DummyTable()
+    mt._upsert_metric(
+        table,
+        campaign="Camp",
+        metric="TOTAL_SENT",
+        value=5,
+        day="2024-01-01",
+        timestamp="2024-01-01T00:00:00Z",
+    )
+
+    assert table.created == [
+        {
+            "Campaign": "Camp",
+            "Metric": "TOTAL_SENT",
+            "Value": 5.0,
+            "Date": "2024-01-01",
+            "Timestamp": "2024-01-01T00:00:00Z",
+        }
+    ]
+    assert table.update_calls == []
+
+
+def test_upsert_metric_updates_when_existing():
+    expected_formula = "AND("
+    expected_formula += ", ".join(
+        [
+            mt._formula_equals("Campaign", "Camp"),
+            mt._formula_equals("Metric", "TOTAL_SENT"),
+            mt._formula_equals("Date", "2024-01-01"),
+        ]
+    )
+    expected_formula += ")"
+
+    table = DummyTable(match_formula=expected_formula, existing_id="rec123")
+
+    mt._upsert_metric(
+        table,
+        campaign="Camp",
+        metric="TOTAL_SENT",
+        value=7,
+        day="2024-01-01",
+        timestamp="2024-01-01T10:00:00Z",
+    )
+
+    assert table.created == []
+    assert table.update_calls == [
+        (
+            "rec123",
+            {
+                "Campaign": "Camp",
+                "Metric": "TOTAL_SENT",
+                "Value": 7.0,
+                "Date": "2024-01-01",
+                "Timestamp": "2024-01-01T10:00:00Z",
+            },
+        )
+    ]


### PR DESCRIPTION
## Summary
- cache Airtable field lookups and limit conversation fetch payloads for faster metrics tracking
- add richer opt-out detection, consolidated conversation metric calculations, and KPI upsert support
- cover the new helpers with unit tests for opt-out detection, aggregation, and KPI upserts

## Testing
- pytest tests/test_metrics_tracker.py

------
https://chatgpt.com/codex/tasks/task_e_68f0da0e82188331a3f4458db92525eb