### PR TITLE
Harden Airtable run logger

### DIFF
--- a/sms/logger.py
+++ b/sms/logger.py
@@ -1,14 +1,57 @@
-# sms/logger.py
+"""Utility helpers for logging operational runs to Airtable.
+
+This module purposely keeps a very small public API – currently just
+``log_run`` – but the implementation does a bit more than the previous version:
+
+* The Airtable dependency (``pyairtable``) is now optional.  When it is missing
+  the module no longer crashes on import; instead it transparently falls back
+  to a no-op mode and prints a human friendly warning.
+* Inputs are normalised so callers can pass ``processed`` values or breakdowns
+  without worrying about exact types.
+* Exception handling prints a compact stack trace to aid debugging while still
+  surfacing the error message.
+
+The behaviour is otherwise backwards compatible – we still print to stdout so
+existing log scraping continues to work – but the module is considerably more
+robust in environments where Airtable credentials or dependencies are missing.
+"""
+
+from __future__ import annotations
+
+import json
 import os
 import traceback
 from datetime import datetime, timezone
-from pyairtable import Table
+from typing import Any, Dict, Optional
+
+# ``pyairtable`` is an optional dependency at runtime.  Import it lazily so
+# that environments running unit tests (or local development) without the
+# package installed can still import the module without raising immediately.
+try:  # pragma: no cover - behaviour validated indirectly via fallbacks
+    from pyairtable import Table as _RealTable
+except Exception:  # pragma: no cover - the fallback path is exercised in tests
+    _RealTable = None
+
+
+class Table:  # thin compatibility wrapper around the optional dependency
+    """Wrapper that only initialises the real ``Table`` when available."""
+
+    def __init__(self, api_key: str, base_id: str, table_name: str) -> None:
+        if _RealTable is None:
+            raise ImportError(
+                "pyairtable is not installed or failed to import. Install with: "
+                "pip install pyairtable"
+            )
+        self._table = _RealTable(api_key, base_id, table_name)
+
+    def create(self, fields: Dict[str, Any]):
+        return self._table.create(fields)
 
 AIRTABLE_KEY = os.getenv("AIRTABLE_REPORTING_KEY") or os.getenv("AIRTABLE_API_KEY")
 PERF_BASE = os.getenv("PERFORMANCE_BASE")
 
 
-def _get_table():
+def _get_table() -> Optional[Table]:
     if not (AIRTABLE_KEY and PERF_BASE):
         return None
     try:
@@ -16,6 +59,33 @@ def _get_table():
     except Exception:
         traceback.print_exc()
         return None
+
+
+def _coerce_processed(value: Any) -> int:
+    """Best-effort conversion of ``processed`` counts to an integer."""
+
+    if value is None:
+        return 0
+    if isinstance(value, int):
+        return value
+    try:
+        return int(value)
+    except Exception:
+        try:
+            return int(float(str(value).replace(",", "")))
+        except Exception:
+            return 0
+
+
+def _serialise_breakdown(breakdown: Any) -> str:
+    if breakdown is None:
+        return "{}"
+    if isinstance(breakdown, str):
+        return breakdown
+    try:
+        return json.dumps(breakdown, default=str, sort_keys=True)
+    except Exception:
+        return str(breakdown)
 
 
 def log_run(
@@ -45,15 +115,15 @@ def log_run(
     try:
         record = {
             "Type": run_type,
-            "Processed": processed,
-            "Breakdown": str(breakdown or {}),
+            "Processed": _coerce_processed(processed),
+            "Breakdown": _serialise_breakdown(breakdown),
             "Status": status,
             "Timestamp": datetime.now(timezone.utc).isoformat(),
         }
         if campaign:
             record["Campaign"] = campaign
         if extra:
-            record.update(extra)
+            record.update(dict(extra))
 
         tbl.create(record)
         print(f"📝 Logged run → {run_type} | {status} | {processed} processed")


### PR DESCRIPTION
## Summary
- make the SMS run logger robust to missing Airtable dependencies/configuration
- normalise processed counts and breakdown payloads before persisting
- document the module and keep behaviour backwards compatible

## Testing
- pytest *(hangs while waiting on external network call; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68f0d98aa9748331b4e18fbd12fae411