### PR TITLE
Centralize dispatch policy and harden webhooks

### DIFF
--- a/sms/retry_runner.py
+++ b/sms/retry_runner.py
@@ -7,6 +7,8 @@ from datetime import datetime, timezone, timedelta
 from functools import lru_cache
 from typing import Optional, Dict, Any, List
 
+from sms.dispatcher import get_policy
+
 # ------------- optional send backends -------------
 try:
     from sms.message_processor import MessageProcessor as _MP
@@ -62,7 +64,8 @@ LAST_ERROR_FIELD = os.getenv("CONV_LAST_ERROR_FIELD", "last_retry_error")
 PERM_FAIL_REASON = os.getenv("CONV_PERM_FAIL_FIELD", "permanent_fail_reason")
 
 # ------------- Retry tuning -------------
-MAX_RETRIES = int(os.getenv("MAX_RETRIES", "3"))
+_POLICY = get_policy()
+MAX_RETRIES = int(os.getenv("MAX_RETRIES", str(_POLICY.retry_limit)))
 BASE_BACKOFF_MINUTES = int(os.getenv("BASE_BACKOFF_MINUTES", "30"))
 
 FAILED_STATES = {"FAILED", "DELIVERY_FAILED", "UNDELIVERED", "UNDELIVERABLE", "THROTTLED"}

--- a/tests/test_inbound.py
+++ b/tests/test_inbound.py
@@ -14,6 +14,7 @@ def test_inbound_valid(monkeypatch):
 
     def fake_log(payload):
         called["logged"] = payload
+        return {"id": "rec123"}
 
     def fake_update(lead_id, body, direction, reply_increment=False):
         called["updated"] = (lead_id, body, direction, reply_increment)
@@ -32,6 +33,8 @@ def test_inbound_valid(monkeypatch):
     result = inbound_webhook.handle_inbound(payload)
 
     assert result["status"] == "ok"
+    assert result["linked_to"] == "lead"
+    assert result["conversation_id"] == "rec123"
     assert "promoted" in called
     assert "logged" in called
     assert "updated" in called
@@ -51,6 +54,7 @@ def test_inbound_optout(monkeypatch):
 
     def fake_log(payload):
         called["logged"] = payload
+        return {"id": "rec123"}
 
     def fake_update(lead_id, body, direction, reply_increment=False):
         called["updated"] = (lead_id, body, direction, reply_increment)
@@ -68,6 +72,7 @@ def test_inbound_optout(monkeypatch):
     result = inbound_webhook.process_optout(payload)
 
     assert result["status"] == "optout"
+    assert result["conversation_id"] == "rec123"
     assert "optout" in called
     assert "promoted" in called
     assert "logged" in called


### PR DESCRIPTION
## Summary
- add a shared DispatchPolicy in the dispatcher so quiet hours, rate limits, and retry budgets come from one place
- update core engines to read limits from the dispatcher policy instead of scattered environment lookups
- normalize inbound/outbound/delivery webhook payloads, enforce required fields, and adjust tests for the new behavior

## Testing
- pytest tests/test_inbound.py
- pytest tests/test_outbound_batcher.py

------
https://chatgpt.com/codex/tasks/task_e_68f20fe21e94833199e0ccc66aef84b1