### PR TITLE
Fix autoresponder view handling and campaign status fallback

### DIFF
--- a/sms/autoresponder.py
+++ b/sms/autoresponder.py
@@ -174,8 +174,8 @@ DRIP_UI_FIELD = DRIP_FIELDS.get("UI", "UI")
 # --- Leads ---
 LEAD_STATUS_FIELD = LEAD_FIELDS.get("STATUS", "Status")
 
-CONV_FROM_CANDIDATES = [CONV_FROM_FIELD, "Seller Phone Number", "phone"]
-CONV_TO_CANDIDATES = [CONV_TO_FIELD, "TextGrid Phone Number", "to_number"]
+CONV_FROM_CANDIDATES = [CONV_FROM_FIELD, "Seller Phone Number", "From", "phone"]
+CONV_TO_CANDIDATES = [CONV_TO_FIELD, "TextGrid Phone Number", "From Number", "To", "to_number"]
 CONV_BODY_CANDIDATES = [CONV_BODY_FIELD, "Body", "Message"]
 CONV_DIRECTION_CANDIDATES = [CONV_DIRECTION_FIELD, "Direction", "direction"]
 CONV_PROCESSED_BY_CANDIDATES = [CONV_PROCESSED_BY_FIELD, "Processed By", "processed_by"]
@@ -546,8 +546,8 @@ class Autoresponder:
         return ("Thanks for the reply.", None, None)
 
     # -------------------------- Fetching
-    def _fetch_inbound(self, limit: int) -> List[Dict[str, Any]]:
-        view = os.getenv("CONV_VIEW_INBOUND", "Unprocessed Inbounds")
+    def _fetch_inbound(self, limit: int, view: Optional[str] = None) -> List[Dict[str, Any]]:
+        view = view or os.getenv("CONV_VIEW_INBOUND", "Unprocessed Inbounds")
         try:
             records = self.convos.all(view=view, max_records=limit)
             if records:
@@ -712,8 +712,8 @@ class Autoresponder:
             self.summary["errors"].append({"phone": from_number, "error": f"Immediate send failed: {exc}"})
 
     # -------------------------- Process loop
-    def process(self, limit: int) -> Dict[str, Any]:
-        records = self._fetch_inbound(limit)
+    def process(self, limit: int, view: Optional[str] = None) -> Dict[str, Any]:
+        records = self._fetch_inbound(limit, view=view)
         if not records:
             return {"ok": False, "processed": 0, "breakdown": {}, "errors": []}
 
@@ -997,9 +997,9 @@ class Autoresponder:
             self.summary["errors"].append({"conversation": conv_id, "error": f"conversation update failed: {exc}"})
 
 
-def run_autoresponder(limit: int = 50) -> Dict[str, Any]:
+def run_autoresponder(limit: int = 50, view: Optional[str] = None) -> Dict[str, Any]:
     service = Autoresponder()
-    return service.process(limit)
+    return service.process(limit, view=view)
 
 
 if __name__ == "__main__":

--- a/sms/campaign_runner.py
+++ b/sms/campaign_runner.py
@@ -39,8 +39,23 @@ DRIP_FIELDS = drip_field_map()
 DRIP_FIELD_NAMES = DRIP_QUEUE_TABLE.field_names()
 CONV_FIELDS = conversations_field_map()
 
+
+def _resolve_status_field() -> str:
+    """Return the active delivery status column for the drip queue."""
+
+    direct = DRIP_FIELDS.get("STATUS") or DRIP_FIELD_NAMES.get("STATUS")
+    if direct:
+        return direct
+
+    for value in list(DRIP_FIELDS.values()) + list(DRIP_FIELD_NAMES.values()):
+        if isinstance(value, str) and value.strip().lower() == "delivery status":
+            return value
+
+    return "Delivery Status"
+
+
 # Column aliases
-DRIP_STATUS_FIELD = DRIP_FIELDS["Status"]
+DRIP_STATUS_FIELD = _resolve_status_field()
 DRIP_MESSAGE_FIELD = DRIP_FIELDS.get("Message Preview", "message_preview")
 DRIP_SELLER_PHONE_FIELD = DRIP_FIELDS.get("SELLER_PHONE", "Seller Phone Number")
 DRIP_FROM_NUMBER_FIELD = DRIP_FIELDS.get("TEXTGRID_PHONE_NUMBER", "TextGrid Phone Number")

--- a/sms/message_processor.py
+++ b/sms/message_processor.py
@@ -28,7 +28,6 @@ try:
 except ImportError:
     Table = None
 
-from sms.textgrid_sender import send_message
 from sms.retry_handler import handle_retry
 from sms.config import CONV_FIELDS, CONVERSATIONS_FIELDS, LEAD_FIELDS
 from sms.airtable_schema import ConversationDirection, ConversationDeliveryStatus
@@ -157,6 +156,8 @@ class MessageProcessor:
 
         # --- 1️⃣ Send message via provider
         try:
+            from sms.textgrid_sender import send_message
+
             send_result = send_message(phone, body, from_number=from_number)
         except Exception as e:
             err = str(e)

--- a/sms/retry_runner.py
+++ b/sms/retry_runner.py
@@ -15,7 +15,6 @@ from sms.airtable_schema import (
 from sms.datastore import CONNECTOR, list_records, update_record
 from sms.dispatcher import get_policy
 from sms.runtime import get_logger, iso_now
-from sms.textgrid_sender import send_message as _send_direct
 
 try:  # Optional richer retry path that also updates linked tables
     from sms.message_processor import MessageProcessor as _Processor  # type: ignore
@@ -183,6 +182,7 @@ class RetryRunner:
                 direction=ConversationDirection.OUTBOUND.value,
                 metadata={"retry": True},
             )
+        from sms.textgrid_sender import send_message as _send_direct
         return _send_direct(
             phone,
             body,


### PR DESCRIPTION
## Summary
- allow the autoresponder to accept an optional Airtable view while improving field fallbacks
- defer TextGrid sender imports in retry and message processors to avoid circular import loops
- add a resilient drip status resolver in the campaign runner to handle renamed Airtable columns

## Testing
- pytest tests/test_autoresponder_v2.py::test_run_autoresponder_basic -q

------
https://chatgpt.com/codex/tasks/task_e_68fab7d6aa508331aba7f7fc530055fe