### PR TITLE
Fix synchronous worker runners and schema mappings

### DIFF
--- a/sms/airtable_schema.py
+++ b/sms/airtable_schema.py
@@ -384,19 +384,20 @@ CONVERSATIONS_TABLE = TableDefinition(
 
 def conversations_field_map() -> Dict[str, str]:
     """
-    Convenience accessor mirroring the legacy CONV_FIELDS dict:
+    Convenience accessor mirroring the legacy CONV_FIELDS dict with the
+    correct directionality for TextGrid transports:
 
         {
-            "FROM": "Seller Phone Number",
-            "TO": "TextGrid Phone Number",
+            "FROM": "TextGrid Number",
+            "TO": "Seller Phone Number",
             ...
         }
     """
 
     fields = CONVERSATIONS_TABLE.fields
     return {
-        "FROM": fields["SELLER_PHONE"].resolve(),
-        "TO": fields["TEXTGRID_PHONE"].resolve(),
+        "FROM": fields["TEXTGRID_PHONE"].resolve(),
+        "TO": fields["SELLER_PHONE"].resolve(),
         "BODY": fields["MESSAGE"].resolve(),
         "STATUS": fields["STATUS"].resolve(),
         "DIRECTION": fields["DIRECTION"].resolve(),

--- a/sms/autoresponder.py
+++ b/sms/autoresponder.py
@@ -997,7 +997,7 @@ class Autoresponder:
             self.summary["errors"].append({"conversation": conv_id, "error": f"conversation update failed: {exc}"})
 
 
-def run_autoresponder(limit: int = 50, view: Optional[str] = None) -> Dict[str, Any]:
+def run_autoresponder(limit: int = 100, view: str | None = None) -> Dict[str, Any]:
     service = Autoresponder()
     return service.process(limit, view=view)
 

--- a/sms/metrics_tracker.py
+++ b/sms/metrics_tracker.py
@@ -22,12 +22,6 @@ try:
 except Exception:
     _ATTable = None
 
-# Optional SMS (best effort)
-try:
-    from sms.textgrid_sender import send_message
-except Exception:
-    send_message = None
-
 # ───────────────────────────────────────── Alerts / thresholds ───────────────────────────────────
 ALERT_PHONE: str | None = os.getenv("ALERT_PHONE")
 ALERT_EMAIL_WEBHOOK: str | None = os.getenv("ALERT_EMAIL_WEBHOOK")  # must be http(s) to send
@@ -166,11 +160,16 @@ def _safe_len(x) -> int:
 def _notify(msg: str) -> None:
     print(f"🚨 ALERT: {msg}")
     # SMS alert (best effort)
-    if ALERT_PHONE and send_message:
+    if ALERT_PHONE:
         try:
-            send_message(ALERT_PHONE, msg)
-        except Exception as e:
-            print(f"❌ SMS alert failed: {e}")
+            from sms.textgrid_sender import send_message as _send_alert
+        except Exception:
+            _send_alert = None
+        if _send_alert:
+            try:
+                _send_alert(ALERT_PHONE, msg)
+            except Exception as e:
+                print(f"❌ SMS alert failed: {e}")
     # Webhook (Slack/Teams/email-gateway URL ONLY)
     if ALERT_EMAIL_WEBHOOK and str(ALERT_EMAIL_WEBHOOK).startswith(("http://", "https://")):
         try:

--- a/sms/retry_worker.py
+++ b/sms/retry_worker.py
@@ -15,11 +15,6 @@ try:
 except Exception:
     _MP = None
 
-try:
-    from sms.textgrid_sender import send_message as _send_direct  # fallback
-except Exception:
-    _send_direct = None
-
 # ----------------- pyairtable compatibility -----------------
 _PyTable = None
 _PyApi = None
@@ -178,6 +173,10 @@ def _send(phone: str, body: str) -> None:
         if not res or res.get("status") != "sent":
             raise RuntimeError(res.get("error", "send_failed") if isinstance(res, dict) else "send_failed")
         return
+    try:
+        from sms.textgrid_sender import send_message as _send_direct
+    except Exception:
+        _send_direct = None
     if _send_direct:
         _send_direct(phone, body)
         return


### PR DESCRIPTION
## Summary
- convert campaign runner to synchronous execution, remove await usage, and ensure deterministic jitter handling
- adjust autoresponder signature and move TextGrid send imports into call sites to avoid circular dependencies
- correct conversation field directionality and drip status fallback resolution for reliable sending

## Testing
- WORKER_RUN_ONCE=1 ENABLE_CAMPAIGNS=0 ENABLE_SEND=0 ENABLE_RETRY=0 ENABLE_AUTORESPONDER=0 ENABLE_METRICS=0 python -m sms.worker

------
https://chatgpt.com/codex/tasks/task_e_68fabd66c5c483318767167fbedc8d58