### PR TITLE
Fix Render deployment and Airtable connectors

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -12,7 +12,7 @@ services:
     buildCommand: |
       pip install --upgrade pip setuptools wheel
       pip install --no-cache-dir -r requirements.txt
-    startCommand: uvicorn sms.main:app --host 0.0.0.0 --port 10000
+    startCommand: uvicorn sms.main:app --host 0.0.0.0 --port $PORT
     autoDeploy: true
     previews:
       enabled: false

--- a/sms/campaign_runner.py
+++ b/sms/campaign_runner.py
@@ -40,7 +40,8 @@ def _get_template_body(templates_table, template_id: str) -> Optional[str]:
             return v.strip()
     return None
 
-def _safe_create_drip(drip_table, payload: Dict[str, Any]) -> bool:
+def _safe_create_drip(drip_handle, payload: Dict[str, Any]) -> bool:
+    table = drip_handle.table
     base = {k: payload.get(k) for k in [
         "Campaign", "Seller Phone Number", "TextGrid Phone Number", "Message",
         "Market", "Property ID", "Status", "UI", "Next Send Date"
@@ -49,12 +50,12 @@ def _safe_create_drip(drip_table, payload: Dict[str, Any]) -> bool:
         if payload.get(key):
             base[key] = payload[key]
             try:
-                drip_table.create(base)
+                table.create(base)
                 return True
             except Exception:
                 base.pop(key, None)
     try:
-        drip_table.create(base)
+        table.create(base)
         return True
     except Exception as e:
         log.error(f"Airtable create failed [Drip Queue]: {e}")
@@ -123,7 +124,7 @@ def _build_campaign_queue(campaign: Dict[str, Any], limit: int = 10000) -> int:
             "UI": STATUS_ICON["QUEUED"],
             "Next Send Date": _ct_future_iso_naive(2, 12),
         }
-        if _safe_create_drip(drip_handle.table, payload):
+        if _safe_create_drip(drip_handle, payload):
             queued += 1
     log.info(f"✅ Queued {queued} messages for campaign → {campaign_name}")
     return queued

--- a/sms/kpi_aggregator.py
+++ b/sms/kpi_aggregator.py
@@ -93,7 +93,8 @@ def aggregate_kpis() -> Dict:
         logger.info("TEST_MODE active – skipping writes.")
         return {"ok": True, "note": "test mode", "written": 0}
 
-    tbl = CONNECTOR.performance()
+    tbl_handle = CONNECTOR.performance()
+    tbl = getattr(tbl_handle, "table", tbl_handle)
     if not tbl:
         return {"ok": False, "error": "No performance table configured"}
 

--- a/sms/kpi_logger.py
+++ b/sms/kpi_logger.py
@@ -87,7 +87,8 @@ def log_kpi(
     - value: numeric (int or float)
     - overwrite=True → update today's row for metric+campaign
     """
-    tbl = CONNECTOR.performance()
+    tbl_handle = CONNECTOR.performance()
+    tbl = getattr(tbl_handle, "table", tbl_handle)
     if not tbl:
         msg = "⚠️ KPI Logger: PERFORMANCE table not configured"
         logger.warning(msg)


### PR DESCRIPTION
## Summary
- update the Render web service to respect the platform port assignment
- add canonical Airtable table mappings and use table handles consistently for campaign hydration and health checks
- ensure KPI aggregators resolve the underlying Airtable table objects from connector handles

## Testing
- python3 - <<'PY'
from sms.datastore import CONNECTOR
handle = CONNECTOR.campaigns()
tbl = getattr(handle, "table", handle)
records = tbl.all(max_records=1)
if records:
    rec = records[0]
    print("Prospects linked:", rec.get("fields", {}).get("Prospects"))
else:
    print("No records returned")
PY
- python3 -m sms.campaign_runner

------
https://chatgpt.com/codex/tasks/task_e_68fbf83304a4833197f5d6f16ef088e4