### PR TITLE
Normalize TextGrid sends and sanitize drip statuses

### DIFF
--- a/sms/metrics_tracker.py
+++ b/sms/metrics_tracker.py
@@ -59,6 +59,7 @@ except Exception:
 
 # ─────────────────────────── Alerts / thresholds ───────────────────────────
 ALERT_PHONE = os.getenv("ALERT_PHONE")
+ALERT_FROM_NUMBER = os.getenv("ALERT_FROM_NUMBER") or os.getenv("TEXTGRID_ALERT_FROM")
 ALERT_WEBHOOK = os.getenv("ALERT_EMAIL_WEBHOOK")
 OPT_OUT_THRESHOLD = float(os.getenv("OPT_OUT_ALERT_THRESHOLD", "2.5"))  # %
 DELIVERY_THRESHOLD = float(os.getenv("DELIVERY_ALERT_THRESHOLD", "90"))  # %
@@ -159,11 +160,13 @@ def _direction(rec):
 
 def _notify(msg: str):
     logger.warning(f"🚨 ALERT: {msg}")
-    if ALERT_PHONE and send_message:
+    if ALERT_PHONE and ALERT_FROM_NUMBER and send_message:
         try:
-            send_message(ALERT_PHONE, msg)
+            send_message(from_number=ALERT_FROM_NUMBER, to=ALERT_PHONE, message=msg)
         except Exception as e:
             logger.warning(f"❌ SMS alert failed: {e}")
+    elif ALERT_PHONE and send_message and not ALERT_FROM_NUMBER:
+        logger.warning("❌ SMS alert skipped: ALERT_FROM_NUMBER not configured")
     if ALERT_WEBHOOK and ALERT_WEBHOOK.startswith(("http://", "https://")):
         try:
             import requests

--- a/sms/retry_runner.py
+++ b/sms/retry_runner.py
@@ -212,6 +212,8 @@ class RetryRunner:
                 self.summary["rescheduled"] += 1
 
     def _send(self, phone, body, from_number, template_id, campaign_id, lead_id) -> Dict[str, Any]:
+        if not from_number:
+            return {"status": "failed", "error": "missing_from_number"}
         if _Processor:
             return _Processor.send(
                 phone=phone,
@@ -223,7 +225,7 @@ class RetryRunner:
                 direction=ConversationDirection.OUTBOUND.value,
                 metadata={"retry": True},
             )
-        return _send_direct(phone, body, from_number=from_number)
+        return _send_direct(from_number=from_number, to=phone, message=body)
 
     def _mark_success(self, record, sid, retries) -> None:
         update_record(

--- a/sms/status_utils.py
+++ b/sms/status_utils.py
@@ -1,0 +1,17 @@
+"""Utility helpers for Drip status normalization."""
+
+from __future__ import annotations
+
+ALLOWED_DRIP_STATUSES = {"Queued", "Sending", "Sent", "Failed", "Error"}
+
+
+def _sanitize_status(val: str | None) -> str:
+    """Normalize drip status values to a safe select option."""
+    v = (val or "").strip().replace("…", "...")
+    if v.endswith("..."):
+        v = v[:-3]
+    vt = v.title()
+    return vt if vt in ALLOWED_DRIP_STATUSES else "Queued"
+
+
+__all__ = ["ALLOWED_DRIP_STATUSES", "_sanitize_status"]

--- a/sms/textgrid_sender.py
+++ b/sms/textgrid_sender.py
@@ -4,6 +4,8 @@
 Handles outbound SMS delivery through TextGrid API and logs conversations to Airtable.
 """
 
+from __future__ import annotations
+
 import os
 import requests
 from datetime import datetime, timezone
@@ -19,30 +21,60 @@ TEXTGRID_AUTH_TOKEN = os.getenv("TEXTGRID_AUTH_TOKEN")
 
 API_BASE = "https://api.textgrid.com/v1"
 
-def _send_via_textgrid(from_number: str, to_number: str, body: str) -> dict:
+def _send_via_textgrid(from_number: str, to_number: str, body: str, media_url: str | None = None) -> dict:
     """Low-level API call to TextGrid"""
     url = f"{API_BASE}/Messages.json"
     auth = (TEXTGRID_ACCOUNT_SID, TEXTGRID_AUTH_TOKEN)
     data = {"From": from_number, "To": to_number, "Body": body}
+    if media_url:
+        data["MediaUrl"] = media_url
     resp = requests.post(url, data=data, auth=auth, timeout=10)
     resp.raise_for_status()
     return resp.json()
 
-def send_message(from_number: str, to_number: str, body: str, campaign=None):
+def send_message(
+    *,
+    from_number: str,
+    to: str,
+    message: str,
+    media_url: str | None = None,
+    **kwargs,
+) -> dict:
     """Send a single SMS immediately via TextGrid + log to Airtable."""
-    print(f"📤 Sending SMS → {to_number}: {body[:60]}...")
-    msg = _send_via_textgrid(from_number, to_number, body)
-    sid = msg.get("sid") or msg.get("messageSid")
+    msg = message if message is not None else kwargs.get("body", "")
+    print(f"📤 Sending SMS → {to}: {msg[:60]}...")
+    response = _send_via_textgrid(from_number, to, msg, media_url=media_url)
+    sid = response.get("sid") or response.get("messageSid") or response.get("id")
 
     tbl = get_table("AIRTABLE_API_KEY", os.getenv("LEADS_CONVOS_BASE"), TABLE_NAMES["CONVERSATIONS"])
-    payload = default_conversation_payload(from_number, to_number, body)
+    payload = default_conversation_payload(from_number, to, msg)
     payload["Message SID"] = sid
     payload["Sent At"] = datetime.now(timezone.utc).isoformat()
+    campaign = kwargs.get("campaign")
+    if not campaign:
+        campaign = kwargs.get("campaign_id")
     if campaign:
         payload["Campaign"] = [campaign]
     tbl.create(payload)
-    return sid
+    enriched = dict(response)
+    if sid:
+        enriched.setdefault("sid", sid)
+        enriched.setdefault("message_sid", sid)
+    status = enriched.get("status") or enriched.get("Status")
+    if status:
+        enriched.setdefault("status", status)
+    else:
+        enriched["status"] = "sent"
+    enriched.setdefault("from", from_number)
+    enriched.setdefault("to", to)
+    enriched.setdefault("body", msg)
+    return enriched
 
 def queue_message(from_number: str, to_number: str, body: str, campaign=None):
     """Compatibility wrapper — alias for send_message()."""
-    return send_message(from_number, to_number, body, campaign=campaign)
+    return send_message(
+        from_number=from_number,
+        to=to_number,
+        message=body,
+        campaign=campaign,
+    )

--- a/tests/sms_test.py
+++ b/tests/sms_test.py
@@ -25,9 +25,14 @@ def debug_env():
 def run_test():
     try:
         debug_env()
+        from_number = os.getenv("TEST_FROM_NUMBER") or os.getenv("TEXTGRID_ALERT_FROM") or os.getenv("TEXTGRID_PHONE_NUMBER")
+        if not from_number:
+            raise RuntimeError("TEST_FROM_NUMBER or TEXTGRID_PHONE_NUMBER must be set")
+
         res = send_message(
+            from_number=from_number,
             to="+16128072000",  # 🔔 replace with your test number
-            body="🔥 Test message from Everline engine",
+            message="🔥 Test message from Everline engine",
             market="houston",  # pulls number from pools
         )
         print("✅ RESULT:")


### PR DESCRIPTION
## Summary
- make the TextGrid sender keyword-only and return a normalized response payload
- sanitize Drip Queue status updates and add fallbacks for Airtable select errors
- update send pipelines to provide mapped field names, guard KPI logging, and require from numbers

## Testing
- python -m compileall sms

------
https://chatgpt.com/codex/tasks/task_e_68fcefc6e5848331bed1d42d794ff04e