### PR TITLE
Guard log_run when performance logs unavailable

### DIFF
--- a/sms/logger.py
+++ b/sms/logger.py
@@ -57,8 +57,16 @@ def log_run(
     Example:
         log_run("CAMPAIGN_RUN", processed=500)
     """
-    tbl = CONNECTOR.performance_logs()
-    if not tbl:
+    tbl_factory = getattr(CONNECTOR, "performance_logs", None)
+    tbl_handle = tbl_factory() if callable(tbl_factory) else None
+
+    if tbl_handle is None:
+        perf_accessor = getattr(CONNECTOR, "performance", None)
+        if callable(perf_accessor):
+            tbl_handle = perf_accessor()
+
+    tbl = getattr(tbl_handle, "table", tbl_handle)
+    if not getattr(tbl, "create", None):
         logger.warning(f"⚠️ Skipping log_run for {run_type} — table unavailable.")
         return {"ok": False, "error": "Performance Logs table unavailable"}
 


### PR DESCRIPTION
## Summary
- guard run logging against connectors that lack the legacy performance_logs accessor
- fall back to the current performance() handle and skip logging when no writable table exists

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd465f4b0c8331a26f5594a1f0ccf4