### PR TITLE
Add messages table shortcuts to Airtable config

### DIFF
--- a/sms/airtable_schema.py
+++ b/sms/airtable_schema.py
@@ -425,6 +425,117 @@ def conversations_field_candidates(keys: Iterable[str]) -> Dict[str, Tuple[str, 
 
 
 # ---------------------------------------------------------------------------
+# Messages table schema (Leads & Conversations base)
+# ---------------------------------------------------------------------------
+
+
+MESSAGES_TABLE_DEF = TableDefinition(
+    default="Messages",
+    env_vars=("MESSAGES_TABLE",),
+    fields={
+        "PRIMARY": FieldDefinition(
+            default="Message ID",
+            env_vars=("MESSAGES_PRIMARY_FIELD",),
+            fallbacks=("Record ID", "Message ID"),
+        ),
+        "SELLER_PHONE": FieldDefinition(
+            default="Seller Phone Number",
+            env_vars=("MESSAGES_SELLER_PHONE_FIELD", "CONV_SELLER_PHONE_FIELD"),
+            fallbacks=("Seller Phone Number", "Phone"),
+        ),
+        "TEXTGRID_PHONE": FieldDefinition(
+            default="TextGrid Phone Number",
+            env_vars=("MESSAGES_TEXTGRID_PHONE_FIELD", "CONV_TEXTGRID_PHONE_FIELD"),
+            fallbacks=("TextGrid Phone Number", "From Number"),
+        ),
+        "DIRECTION": FieldDefinition(
+            default="Direction",
+            env_vars=("MESSAGES_DIRECTION_FIELD", "CONV_DIRECTION_FIELD"),
+            fallbacks=("Direction",),
+        ),
+        "STATUS": FieldDefinition(
+            default="Delivery Status",
+            env_vars=("MESSAGES_STATUS_FIELD", "CONV_STATUS_FIELD"),
+            fallbacks=("Delivery Status", "Status"),
+        ),
+        "MESSAGE": FieldDefinition(
+            default="Message",
+            env_vars=("MESSAGES_MESSAGE_FIELD", "CONV_MESSAGE_FIELD"),
+            fallbacks=("Message", "Body", "Message Long text"),
+        ),
+        "TEXTGRID_ID": FieldDefinition(
+            default="TextGrid ID",
+            env_vars=("MESSAGES_TEXTGRID_ID_FIELD", "CONV_TEXTGRID_ID_FIELD"),
+            fallbacks=("TextGrid ID", "SID"),
+        ),
+        "PROVIDER_STATUS": FieldDefinition(
+            default="Provider Status",
+            env_vars=("MESSAGES_PROVIDER_STATUS_FIELD",),
+            fallbacks=("Provider Status",),
+        ),
+        "ERROR": FieldDefinition(
+            default="Error",
+            env_vars=("MESSAGES_ERROR_FIELD", "CONV_LAST_ERROR_FIELD"),
+            fallbacks=("Last Error", "Error"),
+        ),
+        "SENT_AT": FieldDefinition(
+            default="Sent At",
+            env_vars=("MESSAGES_SENT_AT_FIELD", "CONV_SENT_AT_FIELD"),
+            fallbacks=("Sent At", "Created Time"),
+        ),
+        "CREATED_TIME": FieldDefinition(
+            default="Created Time",
+            env_vars=("MESSAGES_CREATED_TIME_FIELD",),
+            fallbacks=("Created Time",),
+        ),
+        "CONVERSATION_LINK": FieldDefinition(
+            default="Conversation",
+            env_vars=("MESSAGES_CONVERSATION_LINK_FIELD",),
+            fallbacks=("Conversation",),
+        ),
+        "LEAD_LINK": FieldDefinition(
+            default="Lead",
+            env_vars=("MESSAGES_LEAD_LINK_FIELD",),
+            fallbacks=("Lead",),
+        ),
+        "PROSPECT_LINK": FieldDefinition(
+            default="Prospect",
+            env_vars=("MESSAGES_PROSPECT_LINK_FIELD",),
+            fallbacks=("Prospect",),
+        ),
+        "CAMPAIGN_LINK": FieldDefinition(
+            default="Campaign",
+            env_vars=("MESSAGES_CAMPAIGN_LINK_FIELD",),
+            fallbacks=("Campaign",),
+        ),
+        "TEMPLATE_LINK": FieldDefinition(
+            default="Template",
+            env_vars=("MESSAGES_TEMPLATE_LINK_FIELD",),
+            fallbacks=("Template",),
+        ),
+        "DRIP_QUEUE_LINK": FieldDefinition(
+            default="Drip Queue",
+            env_vars=("MESSAGES_DRIP_QUEUE_LINK_FIELD",),
+            fallbacks=("Drip Queue",),
+        ),
+    },
+)
+
+
+def messages_field_map() -> Dict[str, str]:
+    fields = MESSAGES_TABLE_DEF.fields
+    return {key: field.resolve() for key, field in fields.items()}
+
+
+def messages_field_candidates(keys: Iterable[str]) -> Dict[str, Tuple[str, ...]]:
+    results: Dict[str, Tuple[str, ...]] = {}
+    for key in keys:
+        definition = MESSAGES_TABLE_DEF.fields[key]
+        results[key] = definition.candidates()
+    return results
+
+
+# ---------------------------------------------------------------------------
 # Leads table schema (Leads & Conversations base)
 # ---------------------------------------------------------------------------
 

--- a/sms/config.py
+++ b/sms/config.py
@@ -17,6 +17,7 @@ from sms.airtable_schema import (
     PROSPECTS_TABLE,
     DEALS_TABLE,
     CAMPAIGN_MANAGER_TABLE,
+    MESSAGES_TABLE_DEF,
     NUMBERS_TABLE_DEF,
     OPTOUTS_TABLE,
     MARKETS_TABLE,
@@ -35,6 +36,7 @@ from sms.airtable_schema import (
     prospects_field_map,
     deals_field_map,
     campaign_manager_field_map,
+    messages_field_map,
     numbers_field_map,
     optouts_field_map,
     markets_field_map,
@@ -121,6 +123,9 @@ DEALS_FIELD_MAP = deals_field_map()
 
 CAMPAIGN_MANAGER_FIELDS = CAMPAIGN_MANAGER_TABLE.field_names()
 CAMPAIGN_MANAGER_FIELD_MAP = campaign_manager_field_map()
+
+MESSAGES_FIELDS = MESSAGES_TABLE_DEF.field_names()
+MESSAGES_FIELD_MAP = messages_field_map()
 
 NUMBERS_FIELDS = NUMBERS_TABLE_DEF.field_names()
 NUMBERS_FIELD_MAP = numbers_field_map()
@@ -210,6 +215,7 @@ class Settings:
     PROSPECTS_TABLE: str
     LEADS_TABLE: str
     CONVERSATIONS_TABLE: str
+    MESSAGES_TABLE: str
     TEMPLATES_TABLE: str
     DRIP_QUEUE_TABLE: str
     CAMPAIGNS_TABLE: str
@@ -256,6 +262,7 @@ def settings() -> Settings:
         PROSPECTS_TABLE="Prospects",
         LEADS_TABLE="Leads",
         CONVERSATIONS_TABLE="Conversations",
+        MESSAGES_TABLE="Messages",
         TEMPLATES_TABLE="Templates",
         DRIP_QUEUE_TABLE="Drip Queue",
         CAMPAIGNS_TABLE="Campaigns",


### PR DESCRIPTION
## Summary
- define the Messages table in the Airtable schema with canonical field helpers
- expose Messages table shortcuts in the runtime configuration settings

## Testing
- PYTHONPATH=. pytest tests/test_templates.py

------
https://chatgpt.com/codex/tasks/task_e_68fd474be21c8331952094173526c116