### PR TITLE
Validate TextGrid payload and expose error body

### DIFF
--- a/sms/textgrid_sender.py
+++ b/sms/textgrid_sender.py
@@ -66,6 +66,42 @@ DEFAULT_SENDER_LABEL = os.getenv("SENDER_LABEL", "TextGrid Sender")
 DRY_RUN = os.getenv("TEXTGRID_DRY_RUN", "0").lower() in ("1", "true", "yes")
 
 # =========================
+# Errors
+# =========================
+
+
+class TextGridError(RuntimeError):
+    """Custom error that carries HTTP metadata and response body."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: Optional[int] = None,
+        body: Any = None,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body
+        self.payload = payload
+
+    def __str__(self) -> str:  # pragma: no cover - string formatting helper
+        base = super().__str__()
+        if self.body in (None, "", b""):
+            return base
+        if isinstance(self.body, (dict, list)):
+            body_repr = str(self.body)
+        else:
+            body_repr = str(self.body).strip()
+        if not body_repr:
+            return base
+        if body_repr in base:
+            return base
+        return f"{base} | body={body_repr}"
+
+
+# =========================
 # Small helpers
 # =========================
 def _now_iso() -> str:
@@ -98,6 +134,71 @@ def _safe_create(tbl: Any, payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     except Exception:
         return None
 
+
+def _has_value(value: Any) -> bool:
+    return value is not None and str(value).strip() != ""
+
+
+def _validate_textgrid_payload(payload: Dict[str, Any]) -> None:
+    """Ensure required TextGrid transport fields are present and sane."""
+
+    problems: List[str] = []
+
+    for field in ("To", "From"):
+        if not _has_value(payload.get(field)):
+            problems.append(f"{field} is required")
+
+    body = payload.get("Body")
+    media_url = payload.get("MediaUrl")
+
+    if not _has_value(body) and not _has_value(media_url):
+        problems.append("Body or MediaUrl is required")
+
+    if _has_value(body) and len(str(body)) > 1600:
+        problems.append("Body exceeds 1600 characters (TextGrid limit)")
+
+    if problems:
+        raise TextGridError(
+            "Invalid TextGrid payload: " + "; ".join(problems),
+            payload=dict(payload),
+        )
+
+
+def _extract_error_body(resp: Any) -> Any:
+    """Parse JSON body if available; fallback to plain text."""
+
+    if resp is None:
+        return None
+
+    try:
+        data = resp.json()
+    except Exception:
+        text = getattr(resp, "text", None)
+        if text:
+            return text.strip()
+        content = getattr(resp, "content", b"")
+        if isinstance(content, bytes):
+            try:
+                return content.decode("utf-8", "replace").strip()
+            except Exception:
+                return content
+        return content
+    else:
+        return data
+
+
+def _summarize_error_body(body: Any) -> str:
+    if body is None:
+        return ""
+    if isinstance(body, dict):
+        for key in ("message", "error", "detail", "errors", "error_message"):
+            value = body.get(key)
+            if _has_value(value):
+                return str(value)
+        return str(body)
+    return str(body)
+
+
 def _http_post(url: str, data: Dict[str, Any], auth: Tuple[str, str], timeout: int = 15) -> Dict[str, Any]:
     if DRY_RUN:
         print(f"[DRY RUN] POST {url} data={data}")
@@ -110,8 +211,19 @@ def _http_post(url: str, data: Dict[str, Any], auth: Tuple[str, str], timeout: i
     if httpx:
         resp = httpx.post(url, data=data, auth=auth, timeout=timeout)
         if resp.status_code == 429:
-            raise RuntimeError(f"429 rate limited; retry_after={resp.headers.get('Retry-After')}")
-        resp.raise_for_status()
+            raise TextGridError(
+                f"429 rate limited; retry_after={resp.headers.get('Retry-After')}",
+                status_code=429,
+                body=resp.headers.get("Retry-After"),
+                payload=data,
+            )
+        if resp.is_error:
+            body = _extract_error_body(resp)
+            summary = _summarize_error_body(body)
+            message = f"TextGrid HTTP {resp.status_code}"
+            if summary:
+                message = f"{message}: {summary}"
+            raise TextGridError(message, status_code=resp.status_code, body=body, payload=data)
         try:
             return resp.json()
         except Exception:
@@ -120,8 +232,19 @@ def _http_post(url: str, data: Dict[str, Any], auth: Tuple[str, str], timeout: i
     # requests fallback
     resp = requests.post(url, data=data, auth=auth, timeout=timeout)
     if resp.status_code == 429:
-        raise RuntimeError(f"429 rate limited; retry_after={resp.headers.get('Retry-After')}")
-    resp.raise_for_status()
+        raise TextGridError(
+            f"429 rate limited; retry_after={resp.headers.get('Retry-After')}",
+            status_code=429,
+            body=resp.headers.get("Retry-After"),
+            payload=data,
+        )
+    if resp.status_code >= 400:
+        body = _extract_error_body(resp)
+        summary = _summarize_error_body(body)
+        message = f"TextGrid HTTP {resp.status_code}"
+        if summary:
+            message = f"{message}: {summary}"
+        raise TextGridError(message, status_code=resp.status_code, body=body, payload=data)
     try:
         return resp.json()
     except Exception:
@@ -161,7 +284,25 @@ def send_message(
         data["MediaUrl"] = media_url
 
     try:
+        _validate_textgrid_payload(data)
         resp = _http_post(API_URL, data=data, auth=(ACCOUNT_SID, AUTH_TOKEN), timeout=timeout)
+    except TextGridError as e:
+        meta: Dict[str, Any] = {"error": str(e)}
+        if e.body not in (None, "", {}):
+            meta["error_body"] = e.body
+        _log_conversation(
+            status="FAILED",
+            phone=to,
+            from_number=from_number,
+            body=message,
+            sid=None,
+            campaign=campaign or campaign_id,
+            template_id=template_id,
+            lead_id=lead_id,
+            property_id=property_id,
+            meta=meta,
+        )
+        raise
     except Exception as e:
         # Log FAILED conversation (best-effort), then bubble up
         _log_conversation(

--- a/tests/test_textgrid_sender.py
+++ b/tests/test_textgrid_sender.py
@@ -1,0 +1,39 @@
+import pytest
+
+from sms import textgrid_sender as tg
+
+
+def test_validate_textgrid_payload_requires_from_number():
+    payload = {"To": "+15551234567", "Body": "hello"}
+
+    with pytest.raises(tg.TextGridError) as exc:
+        tg._validate_textgrid_payload(payload)
+
+    assert "From is required" in str(exc.value)
+
+
+def test_send_message_exposes_error_body(monkeypatch):
+    captured = {}
+
+    def fake_log_conversation(**kwargs):
+        captured.update(kwargs)
+
+    def fake_http_post(*_a, **_k):
+        raise tg.TextGridError(
+            "TextGrid HTTP 400: Invalid",
+            status_code=400,
+            body={"message": "Invalid number"},
+        )
+
+    monkeypatch.setattr(tg, "ACCOUNT_SID", "AC123")
+    monkeypatch.setattr(tg, "AUTH_TOKEN", "token")
+    monkeypatch.setattr(tg, "API_URL", "https://example.com")
+    monkeypatch.setattr(tg, "_log_conversation", fake_log_conversation)
+    monkeypatch.setattr(tg, "_http_post", fake_http_post)
+
+    with pytest.raises(tg.TextGridError) as exc:
+        tg.send_message(from_number="+15550000000", to="+15551234567", message="hello")
+
+    assert exc.value.body == {"message": "Invalid number"}
+    assert captured["meta"]["error_body"] == {"message": "Invalid number"}
+


### PR DESCRIPTION
## Summary
- add a TextGridError helper and payload validation so sends fail fast with actionable messages
- capture provider error bodies from HTTP responses and surface them through send_message logging
- cover the new behaviour with unit tests around payload validation and error propagation

## Testing
- PYTHONPATH=. pytest tests/test_textgrid_sender.py

------
https://chatgpt.com/codex/tasks/task_e_68fd479f3a548331ba61cd9c73fad8bc