### PR TITLE
Add Airtable messages table schema shortcuts

### DIFF
--- a/sms/airtable_schema.py
+++ b/sms/airtable_schema.py
@@ -425,6 +425,143 @@ def conversations_field_candidates(keys: Iterable[str]) -> Dict[str, Tuple[str, 
 
 
 # ---------------------------------------------------------------------------
+# Conversation Messages table schema (Leads & Conversations base)
+# ---------------------------------------------------------------------------
+
+MESSAGES_TABLE = TableDefinition(
+    default="Conversation Messages",
+    env_vars=("MESSAGES_TABLE", "CONVERSATION_MESSAGES_TABLE"),
+    fields={
+        "PRIMARY": FieldDefinition(
+            default="Message ID",
+            env_vars=("MESSAGES_PRIMARY_FIELD",),
+            fallbacks=("Record ID", "Message Record ID"),
+        ),
+        "BODY": FieldDefinition(
+            default="Message",
+            env_vars=("MESSAGES_MESSAGE_FIELD", "CONV_MESSAGE_FIELD"),
+            fallbacks=("Body", "message"),
+        ),
+        "BODY_LONG": FieldDefinition(
+            default="Message Long text",
+            env_vars=("MESSAGES_MESSAGE_LONG_FIELD", "CONV_MESSAGE_LONG_FIELD"),
+            fallbacks=("Message Long Text", "Message Long"),
+        ),
+        "SUMMARY": FieldDefinition(
+            default="Message Summary (AI)",
+            env_vars=("MESSAGES_MESSAGE_SUMMARY_FIELD", "CONV_MESSAGE_SUMMARY_FIELD"),
+            fallbacks=("Message Summary", "AI Summary"),
+        ),
+        "DIRECTION": FieldDefinition(
+            default="Direction",
+            env_vars=("MESSAGES_DIRECTION_FIELD", "CONV_DIRECTION_FIELD"),
+            options=tuple(direction.value for direction in ConversationDirection),
+            fallbacks=("direction",),
+        ),
+        "STATUS": FieldDefinition(
+            default="Delivery Status",
+            env_vars=("MESSAGES_STATUS_FIELD", "CONV_STATUS_FIELD"),
+            options=tuple(status.value for status in ConversationDeliveryStatus),
+            fallbacks=("status",),
+        ),
+        "TEXTGRID_PHONE": FieldDefinition(
+            default="TextGrid Phone Number",
+            env_vars=("MESSAGES_TEXTGRID_PHONE_FIELD", "CONV_TEXTGRID_PHONE_FIELD"),
+            fallbacks=("TextGrid Number", "DID", "To"),
+        ),
+        "SELLER_PHONE": FieldDefinition(
+            default="Seller Phone Number",
+            env_vars=("MESSAGES_SELLER_PHONE_FIELD", "CONV_SELLER_PHONE_FIELD"),
+            fallbacks=("Seller Phone", "Phone", "From"),
+        ),
+        "TEXTGRID_ID": FieldDefinition(
+            default="TextGrid ID",
+            env_vars=("MESSAGES_TEXTGRID_ID_FIELD", "CONV_TEXTGRID_ID_FIELD"),
+            fallbacks=("TextGrid SID", "MessageSid", "message_sid", "sid"),
+        ),
+        "MESSAGE_SID": FieldDefinition(
+            default="Message SID",
+            env_vars=("MESSAGES_MESSAGE_SID_FIELD",),
+            fallbacks=("MessageSid", "SID"),
+        ),
+        "CONVERSATION": FieldDefinition(
+            default="Conversation",
+            env_vars=("MESSAGES_CONVERSATION_LINK_FIELD",),
+            fallbacks=("Conversation",),
+        ),
+        "CONVERSATION_RECORD_ID": FieldDefinition(
+            default="Conversation Record ID",
+            env_vars=("MESSAGES_CONVERSATION_RECORD_ID_FIELD",),
+            fallbacks=("Conversation Record ID", "Conversation ID"),
+        ),
+        "TEMPLATE": FieldDefinition(
+            default="Template",
+            env_vars=("MESSAGES_TEMPLATE_LINK_FIELD",),
+            fallbacks=("Template",),
+        ),
+        "PROSPECT": FieldDefinition(
+            default="Prospect",
+            env_vars=("MESSAGES_PROSPECT_LINK_FIELD",),
+            fallbacks=("Prospect",),
+        ),
+        "LEAD": FieldDefinition(
+            default="Lead",
+            env_vars=("MESSAGES_LEAD_LINK_FIELD",),
+            fallbacks=("Lead",),
+        ),
+        "CAMPAIGN": FieldDefinition(
+            default="Campaign",
+            env_vars=("MESSAGES_CAMPAIGN_LINK_FIELD",),
+            fallbacks=("Campaign",),
+        ),
+        "RECEIVED_AT": FieldDefinition(
+            default="Received Time",
+            env_vars=("MESSAGES_RECEIVED_AT_FIELD", "CONV_RECEIVED_AT_FIELD"),
+            fallbacks=("Received At", "Received Time"),
+        ),
+        "SENT_AT": FieldDefinition(
+            default="Sent At",
+            env_vars=("MESSAGES_SENT_AT_FIELD",),
+            fallbacks=("Sent At", "Sent Time"),
+        ),
+        "PROCESSED_AT": FieldDefinition(
+            default="Processed Time",
+            env_vars=("MESSAGES_PROCESSED_AT_FIELD", "CONV_PROCESSED_AT_FIELD"),
+            fallbacks=("Processed At", "Processed Time"),
+        ),
+        "CREATED_AT": FieldDefinition(
+            default="Created",
+            env_vars=("MESSAGES_CREATED_AT_FIELD",),
+            fallbacks=("Created Time", "Created At"),
+        ),
+        "ATTACHMENTS": FieldDefinition(
+            default="Attachments",
+            env_vars=("MESSAGES_ATTACHMENTS_FIELD",),
+            fallbacks=("Attachments", "Media"),
+        ),
+        "ERROR": FieldDefinition(
+            default="Error",
+            env_vars=("MESSAGES_ERROR_FIELD",),
+            fallbacks=("Error", "Last Error"),
+        ),
+    },
+)
+
+
+def messages_field_map() -> Dict[str, str]:
+    fields = MESSAGES_TABLE.fields
+    return {key: field.resolve() for key, field in fields.items()}
+
+
+def messages_field_candidates(keys: Iterable[str]) -> Dict[str, Tuple[str, ...]]:
+    results: Dict[str, Tuple[str, ...]] = {}
+    for key in keys:
+        definition = MESSAGES_TABLE.fields[key]
+        results[key] = definition.candidates()
+    return results
+
+
+# ---------------------------------------------------------------------------
 # Leads table schema (Leads & Conversations base)
 # ---------------------------------------------------------------------------
 
@@ -3484,6 +3621,7 @@ def default_conversation_payload(
 
 TABLE_NAMES = {
     "CONVERSATIONS": "Conversations",
+    "MESSAGES": "Conversation Messages",
     "LEADS": "Leads",
     "CAMPAIGNS": "Campaigns",
     "KPIS": "KPIs",

--- a/sms/config.py
+++ b/sms/config.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 # -----------------------------
 from sms.airtable_schema import (
     CONVERSATIONS_TABLE,
+    MESSAGES_TABLE,
     LEADS_TABLE,
     CAMPAIGNS_TABLE,
     TEMPLATES_TABLE,
@@ -46,6 +47,7 @@ from sms.airtable_schema import (
     devops_integrations_field_map,
     devops_health_checks_field_map,
     devops_metrics_field_map,
+    messages_field_map,
 )
 
 # -----------------------------
@@ -134,6 +136,8 @@ MARKET_FIELD_MAP = markets_field_map()
 LOG_FIELDS = LOGS_TABLE.field_names()
 LOG_FIELD_MAP = logs_field_map()
 
+MESSAGES_FIELDS = MESSAGES_TABLE.field_names()
+MESSAGES_FIELD_MAP = messages_field_map()
 KPI_FIELDS = KPIS_TABLE_DEF.field_names()
 KPI_FIELD_MAP = kpi_field_map()
 
@@ -217,6 +221,7 @@ class Settings:
     OPTOUTS_TABLE: str
     MARKETS_TABLE: str
     LOGS_TABLE: str
+    MESSAGES_TABLE: str
     KPIS_TABLE: str
     DEVOPS_SERVICES_TABLE: str
     DEVOPS_DEPLOYMENTS_TABLE: str
@@ -263,6 +268,7 @@ def settings() -> Settings:
         OPTOUTS_TABLE="Opt-Outs",
         MARKETS_TABLE="Markets",
         LOGS_TABLE="Logs",
+        MESSAGES_TABLE="Conversation Messages",
         KPIS_TABLE="KPIs",
         DEVOPS_SERVICES_TABLE="Services",
         DEVOPS_DEPLOYMENTS_TABLE="Deployments",
@@ -364,3 +370,8 @@ def table_perf(table_name: str):
 @lru_cache(maxsize=None)
 def drip_queue():
     return table_main(settings().DRIP_QUEUE_TABLE)
+
+
+@lru_cache(maxsize=None)
+def messages_table():
+    return table_main(settings().MESSAGES_TABLE)


### PR DESCRIPTION
## Summary
- add a Conversation Messages table definition and field map helpers to the Airtable schema module
- expose Conversation Messages field names, settings defaults, and a cached table accessor through the config helpers

## Testing
- PYTHONPATH=. pytest -q tests/test_templates.py

------
https://chatgpt.com/codex/tasks/task_e_68fd478065f88331a74d3849f68a0bab